### PR TITLE
Update gettext_locale to an Array

### DIFF
--- a/config/gettext.php
+++ b/config/gettext.php
@@ -10,7 +10,7 @@ $config['gettext_text_domain'] = 'default';
 $config['gettext_locale_dir'] = 'language/locale';
 
 // Gettext locale
-$config['gettext_locale'] = 'C.UTF-8';
+$config['gettext_locale'] = Array( "en_GB.UTF-8", "en_GB@euro", "en_GB", "english", "eng", "en");
 
 /* End of file gettext.php */
 /* Location: ./application/config/gettext.php */


### PR DESCRIPTION
it should be set as Array because each array element or parameter is tried to be set as new locale until success. This is useful if a locale is known under different names on different systems or for providing a fallback for a possibly not available locale. 

@link http://php.net/manual/en/function.setlocale.php#refsect1-function.setlocale-parameters
@link https://msdn.microsoft.com/en-us/library/39cwe7zf(v=vs.90).aspx
@link https://msdn.microsoft.com/en-us/library/cdax410z(v=vs.90).aspx