### PR TITLE
fix: bindtextdomain - FCPATH and APPPATH are both realpath results

### DIFF
--- a/libraries/Gettext.php
+++ b/libraries/Gettext.php
@@ -49,7 +49,7 @@ class Gettext {
 
         log_message (
             'debug',
-            'Try to bind gettext text domain (locale dir): ' . $IsBindTextDomain . " - " .
+            'Try to bind gettext text domain (locale dir): ' . (isset($IsBindTextDomain) ? $IsBindTextDomain : APPPATH.$config['gettext_locale_dir'] ) . " - " .
                 (isset($IsBindTextDomain) ? 'Successful' : '*** FAILED ***')
         );
 

--- a/libraries/Gettext.php
+++ b/libraries/Gettext.php
@@ -49,7 +49,7 @@ class Gettext {
 
         log_message (
             'debug',
-            'Try to bind gettext text domain (locale dir): ' . (isset($IsBindTextDomain) ? $IsBindTextDomain : APPPATH.$config['gettext_locale_dir'] ) . " - " .
+            'Try to bind gettext text domain (locale dir): ' . (empty($IsBindTextDomain) ? $IsBindTextDomain : APPPATH.$config['gettext_locale_dir'] ) . " - " .
                 (isset($IsBindTextDomain) ? 'Successful' : '*** FAILED ***')
         );
 

--- a/libraries/Gettext.php
+++ b/libraries/Gettext.php
@@ -44,12 +44,12 @@ class Gettext {
         // Path to gettext locales directory relative to FCPATH.APPPATH
         $IsBindTextDomain = bindtextdomain (
             $config['gettext_text_domain'],
-            FCPATH.APPPATH.$config['gettext_locale_dir']
+            APPPATH.$config['gettext_locale_dir']
         );
 
         log_message (
             'debug',
-            'Try to bind gettext text domain (locale dir): '. FCPATH.APPPATH.$config['gettext_locale_dir'] . " - " .
+            'Try to bind gettext text domain (locale dir): ' . $IsBindTextDomain . " - " .
                 (isset($IsBindTextDomain) ? 'Successful' : '*** FAILED ***')
         );
 


### PR DESCRIPTION
You see in #5 (Extendet Log Messages) the following line:

DEBUG - 2016-06-18 13:29:07 --> Try to bind gettext text domain (locale dir): _D:\Server\www\fp-group.eu\trunk\_ D:\Server\www\fp-group.eu\trunk\app\language\ - Successful

The path is shown twice because FCPATH and APPPATH are both realpath results.

CI 3.06 index.php
```php
/*
 * ---------------------------------------------------------------
 *  Resolve the system path for increased reliability
 * ---------------------------------------------------------------
 */
	if (($_temp = realpath($system_path)) !== FALSE)
	{
		$system_path = $_temp.DIRECTORY_SEPARATOR;
	}

```
```php

/*
 * -------------------------------------------------------------------
 *  Now that we know the path, set the main path constants
 * -------------------------------------------------------------------
 */
	// The name of THIS file
	define('SELF', pathinfo(__FILE__, PATHINFO_BASENAME));

	// Path to the system directory
	define('BASEPATH', $system_path);

	// Path to the front controller (this file) directory
	define('FCPATH', dirname(__FILE__).DIRECTORY_SEPARATOR);

	// Name of the "system" directory
	define('SYSDIR', basename(BASEPATH));

	// The path to the "application" directory
	if (is_dir($application_folder))
	{
		if (($_temp = realpath($application_folder)) !== FALSE)
		{
			$application_folder = $_temp;
		}
		else
		{
			$application_folder = strtr(
				rtrim($application_folder, '/\\'),
				'/\\',
				DIRECTORY_SEPARATOR.DIRECTORY_SEPARATOR
			);
		}
	}

[...]

	define('APPPATH', $application_folder.DIRECTORY_SEPARATOR);

```